### PR TITLE
chore: update README env example with /api/v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Create `.env.local` in the project root:
 
 ```bash
 #Backend base URL (required):
-VITE_API_URL=http://localhost:8000
+VITE_API_URL=http://localhost:8000/api/v1
 ```
 A sample file is provided: `.env.local.example`
 


### PR DESCRIPTION
Updated the README environment variables section.
Changed VITE_API_URL to include /api/v1 so frontend calls can stay shorter (e.g. "/auth/login").
Keeps frontend consistent with backend route setup.